### PR TITLE
Fix goniometer rotation detection

### DIFF
--- a/Tools/imgCIF_Creator/imgCIF_Creator/information_extractors/hdf5_nxmx.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/information_extractors/hdf5_nxmx.py
@@ -245,9 +245,10 @@ class Extractor(extractor_interface.ExtractorInterface):
                             path = f'{scan}/sample/transformations/{scan_axis}_increment_set'
                             scan_incr = self._get_hdf5_item(h5_master, path)[0]
                             # if the rotation direction is the other way round,
-                            # chage increment
-                            if goniometer_rot_direction == 'counter_clockwise':
+                            # change increment
+                            if goniometer_rot_direction in ['anticlockwise', 'a']:
                                 scan_incr = scan_incr * -1
+                                scan_stop *= -1
                             scan_range = n_frames * scan_incr
                     except TypeError:
                         # for fast and slow this is a scalar and no list


### PR DESCRIPTION
There was a bug in recognizing the user input for the goniometer rotation direction for hdf5 files and the input had no effect. This will be fixed with this PR. The goniometer rotation direction is used for:

@kroon-lab mentioned: "There is an other problem we could come across: the case were the goniometer rotates in a negative fashion. cif_img.dic says that the rotation axis should be right-handed, i.e. looking from the tail of the vector the rotation is clockwise. That means in such a case we could use negative increments for the rotation.  Alternatively, the direction of X could be reversed, but that is not consistent with choosing the X axis along the principal goniometer axis."

For counter-clockwise goniometer rotation `_diffrn_scan_axis.angle_increment` and the ` _diffrn_scan_axis.angle_range` is set to negative values. The sign is not changed if the rotation is positive.

```
loop_
  _diffrn_scan_axis.scan_id
  _diffrn_scan_axis.axis_id
  _diffrn_scan_axis.displacement_start
  _diffrn_scan_axis.displacement_increment
  _diffrn_scan_axis.displacement_range
  _diffrn_scan_axis.angle_start
  _diffrn_scan_axis.angle_increment
  _diffrn_scan_axis.angle_range
         SCAN1     chi       .         .         .         0.0       0         0        
         SCAN1     omega     .         .         .         0.0       -0.1       -360.0   
```
