### PR TITLE
Issue46 correct pointers

### DIFF
--- a/Tools/imgCIF_Creator/imgCIF_Creator/information_extractors/hdf5_nxmx.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/information_extractors/hdf5_nxmx.py
@@ -234,6 +234,9 @@ class Extractor(extractor_interface.ExtractorInterface):
                         continue
                     axis = list(h5item.keys())[0]
                     axis = self._replace_names(axis)
+                    # drop sam axes
+                    if axis in ['sam_x', 'sam_y', 'sam_z']:
+                        continue
                     # take only first
                     dataset = list(h5item.values())[0]
                     # print('Collect INFO for', axis)

--- a/Tools/imgCIF_Creator/imgCIF_Creator/information_extractors/hdf5_nxmx.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/information_extractors/hdf5_nxmx.py
@@ -152,12 +152,10 @@ class Extractor(extractor_interface.ExtractorInterface):
         """
 
         #TODO multiple detectors are not supportet (yet?)
-        detector_axes = self.setup_info.get('detector_axes')
-        number_of_axes = len(detector_axes) if detector_axes is not None else None
         detector_info = {
             'detector_id' : None,
-            'number_of_axes' : [number_of_axes],
-            'axis_id' : detector_axes,
+            'number_of_axes' : None,
+            'axis_id' : None,
             'detector_axis_id' : None
         }
 
@@ -442,19 +440,6 @@ of files. Please try again!')
                     setup_info['fast_direction'] = 'horizontal'
                 elif fast_direction[1] != 0 and fast_direction[0] == fast_direction[2] == 0:
                     setup_info['fast_direction'] = 'vertical'
-
-                # find detector axes
-                # TODO can I extract it from the hdf5 with the number of nxpositioners?
-                detector_axes = []
-                instrument_group = h5_master[f'{scan}/instrument/']
-                for sub_grp in instrument_group.keys():
-                    try:
-                        nx_class = instrument_group[sub_grp].attrs["NX_class"].decode('utf-8')
-                        if "NXpositioner" in nx_class:
-                            detector_axes.append(list(instrument_group[sub_grp].keys())[0])
-                    except KeyError:
-                        pass
-                setup_info['detector_axes'] = detector_axes
 
         return setup_info
 

--- a/Tools/imgCIF_Creator/imgCIF_Creator/information_extractors/hdf5_nxmx.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/information_extractors/hdf5_nxmx.py
@@ -546,6 +546,11 @@ of files. Please try again!')
             goniometer_axes[axis]['offset'] = \
                 self._rotate_from_nexus_to_cbf(content['offset'], goniometer_pos)
 
+        # scan start for trans must also be transformed
+        if goniometer_axes['trans']['offset'][-1] == -off_z:
+            for scan in self.scan_info:
+                self.scan_info[scan][0]['trans'] *= -1
+
         return goniometer_axes
 
 

--- a/Tools/imgCIF_Creator/imgCIF_Creator/output_creator/imgcif_creator.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/output_creator/imgcif_creator.py
@@ -12,6 +12,7 @@ ROT_AXES = ("chi", "phi", "detector_2theta", "two_theta", "omega",
             "angle", "start_angle", "kappa")
 TRANS_AXES = ("detector_distance", "dx", "trans", "distance")
 ALWAYS_AXES = ("distance", "two_theta", "detector_2theta")
+DETECTOR_ARRAY_AXES = ("detx", "dety")
 
 
 class ImgCIFCreator:
@@ -83,7 +84,7 @@ class ImgCIFCreator:
         # describe _diffrn_detector and _diffrn_detector_axis
         # this correlates with the detector axes in generate axes!
         detector_info = self.extractor.get_detector_info()
-        detector_info = self.check_detector_completeness(detector_info)
+        detector_info = self.check_detector_completeness(detector_info, axes_info)
 
         archive, external_url = self.check_external_url(external_url, filename)
 
@@ -265,8 +266,7 @@ one detector, or detectors are non-rectangular, please describe in the comments 
         array_structure_labels = ['axis_id', 'axis_set_id', 'pixel_size']
         if any([self.param_is_none(array_info[label]) for label in array_structure_labels]):
 
-            array_info["axis_id"] = ["array_x", "array_y"] #TODO should that be the
-            # detector axes detx, dety
+            array_info["axis_id"] = ["detx", "dety"]
             array_info["axis_set_id"] = [1, 2]
 
             if self.param_is_none(array_info['pixel_size']):
@@ -296,7 +296,7 @@ one detector, or detectors are non-rectangular, please describe in the comments 
         return array_info
 
 
-    def check_detector_completeness(self, detector_info):
+    def check_detector_completeness(self, detector_info, axes_info):
         """Check if the detector information is complete and request input
         if not.
 
@@ -308,7 +308,6 @@ one detector, or detectors are non-rectangular, please describe in the comments 
         """
 
         # TODO does not include multiple detectors yet
-        # print('detrinf', detector_info)
 
         if self.param_is_none(detector_info["detector_id"]):
             detector_info["detector_id"] = ['det1']
@@ -316,14 +315,21 @@ one detector, or detectors are non-rectangular, please describe in the comments 
         detector_axes_labels = ['number_of_axes', 'axis_id']
 
         if any([self.param_is_none(detector_info[label]) for label in detector_axes_labels]):
-            det_axes = self.cmd_parser.request_input('detector_axes').split(',')
-            det_axes = [axis.strip() for axis in det_axes]
-            det_axes = [axis for axis in det_axes if axis != '']
+            det_axes = []
+            for idx, axis in enumerate(axes_info['axes']):
+                # skip detx, dety
+                if axis in DETECTOR_ARRAY_AXES:
+                    continue
+                if axes_info['equip'][idx] == 'detector' \
+                    and axes_info['axis_type'][idx] == 'translation':
+                    det_axes.append(axis)
 
-            # TODO testing len is always correct
+            if len(det_axes) < 1:
+                det_axes = self.cmd_parser.request_input('detector_axes').split(',')
+                det_axes = [axis.strip() for axis in det_axes]
+                det_axes = [axis for axis in det_axes if axis != '']
+
             detector_info["number_of_axes"] = [len(det_axes)]
-            # TODO is that true? in the hdf5 this is trans and in the cbf this is
-            # detx and dety
             detector_info["axis_id"] = det_axes
 
         #TODO it's not ensured that this is always a list...

--- a/Tools/imgCIF_Creator/imgCIF_Creator/output_creator/imgcif_creator.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/output_creator/imgcif_creator.py
@@ -302,6 +302,7 @@ one detector, or detectors are non-rectangular, please describe in the comments 
 
         Args:
             detector_info (dict): information about the detector
+            axes_info (dict): information about the axes
 
         Returns:
             dict: the information completed


### PR DESCRIPTION
This PR addresses #46 

- to create the correct pointers to `_diffrn_detector_axis.axis_id` I exchanged https://github.com/COMCIFS/instrument-geometry-info/blob/262b5ebc20ef33fe8c1bf34fd058a3d39cfca1f4/Tools/imgCIF_Creator/imgCIF_Creator/output_creator/imgcif_creator.py#L268-L269 with `array_info["axis_id"] = ["detx", "dety"]`. This is hard coded, but as `detx` and `dety` are also hard coded that's maybe ok. Otherwise one would need to identify the name of the detector array axes and use them.
- the pointer to the detector axes `_diffrn_detector_axis.axis_id` is now created by looking for axes that are translation axes from the detector which are not in `DETECTOR_ARRAY_AXES = ("detx", "dety")` (such as trans). See [check_detector_completeness](https://github.com/julianhoersch/instrument-geometry-info/blob/7a30f3670d6ff731904319b300900f8e90bc99b4/Tools/imgCIF_Creator/imgCIF_Creator/output_creator/imgcif_creator.py#L320)


I also dropped the `sam_x` etc. axes in the scan description and realized that all axes that are not defined in the file (e.g. `detx`, `two_theta`) are also not in the scan list. This is a bit inconsistent - to include those axes one would also need to define the start of the displacement/angle, increment etc. or set it to zero. Alternatively as @kroon-lab suggested we could leave axes that are not scanned entirely out what would cause problems with `cbflib`. What is the path that we should follow here? This will also hold for user defined axes in #50 

```
loop_
  _axis.id
  _axis.type
  _axis.equipment
  _axis.depends_on
  _axis.vector[1]
  _axis.vector[2]
  _axis.vector[3]
  _axis.offset[1]
  _axis.offset[2]
  _axis.offset[3]
         phi       rotation  goniometer          chi       1         -0.0037   0.002    0        0        0        
         chi       rotation  goniometer          omega     -0.0046   0.0372    -0.9993  0        0        0        
         omega     rotation  goniometer          .         1         0         0        0        0        0        
         two_theta           rotation  detector  .         1         0         0        0        0        0        
         dety      translation         detector  detx      0         -1        0        0        0        0        
         detx      translation         detector  trans     1         0         0        -166.87357         172.49715          0        
         trans     translation         detector  two_theta           0         0        -1       0        0        -287.22243
```

vs. 

```
loop_
  _diffrn_scan_axis.scan_id
  _diffrn_scan_axis.axis_id
  _diffrn_scan_axis.displacement_start
  _diffrn_scan_axis.displacement_increment
  _diffrn_scan_axis.displacement_range
  _diffrn_scan_axis.angle_start
  _diffrn_scan_axis.angle_increment
  _diffrn_scan_axis.angle_range
         SCAN1     chi       .         .         .         0.0       0         0        
         SCAN1     omega     .         .         .         0.0       0.1       360.0    
         SCAN1     phi       .         .         .         0.0       0         0        
         SCAN1     trans     -287.2224260231453   0         0         .         .        .
```