### PR TITLE
Issue47 construction of urls

### DIFF
--- a/Tools/imgCIF_Creator/imgCIF_Creator/command_line_interfaces/parser.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/command_line_interfaces/parser.py
@@ -67,6 +67,7 @@ class CommandLineParser():
             'external_url': None,
             'temperature': r'\d+\Z',
             'keep_axes': self._create_options_regex('keep_axes'),
+            'url_not_reachable': self._create_options_regex('url_not_reachable'),
         }
 
 

--- a/Tools/imgCIF_Creator/imgCIF_Creator/creator.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/creator.py
@@ -82,14 +82,14 @@ cbf and smv files please provide a directory. Exiting.')
 # e.g. file://cbf_cyclohexane_crystal2/CBF_crystal_2/ciclohexano3_010001.cbf -->
 # my_new_name/ciclohexano3_010001.cbf
 
-@click.option(
-    "--include",
-    "-i",
-    type=bool,
-    default=False,
-    is_flag=True,
-    help="Include the directory name as part of the archive path name."
-)
+# @click.option(
+#     "--include",
+#     "-i",
+#     type=bool,
+#     default=False,
+#     is_flag=True,
+#     help="Include the directory name as part of the archive path name."
+# )
 # this only has an effect if the location is set and has a archive archive_path
 # as tgz then _array_data_external_data.archive_path is filled and if i is
 # selected the folder name is prepended to that name
@@ -118,7 +118,7 @@ scan/frame file naming convention",
     # callback=validate_filename,
 )
 
-def main(filename, gui, external_url, include, stem, output_file):
+def main(filename, gui, external_url, stem, output_file):
     """This is an interactive command line interface to collect the necessary
 information to create an imgCIF file out of HDF5, full CBF and some common subset
 of miniCBF
@@ -136,8 +136,8 @@ of miniCBF
 
     print('\n--------------------------- imgCIF Creator ---------------------------\n')
     print("""This is an interactive command line interface to collect the necessary
-information to create an imgCIF file out of HDF5, full CBF and some common subset
-of miniCBF.
+information to create an imgCIF file out of full CBF files and some common
+subsets of miniCBF and HDF5 master files.
 
 Parameters that are missing in the provided file or directory will be requested
 from the user. You can skip parameters that are not required with an empty input,
@@ -147,19 +147,14 @@ if you provide an input it will be checked against the required format.
     filename, filetype = validate_filename(filename)
     print(f'Identified content of {filename} as {filetype} file(s).')
 
-    if include:
-        prepend_dir = os.path.split(filename)[-1]
-    else:
-        prepend_dir = ""
-
     if gui:
         graphical_user_interface()
     else:
         command_line_interface(
-            filename, filetype, external_url, prepend_dir, stem, output_file)
+            filename, filetype, external_url, stem, output_file)
 
 
-def command_line_interface(filename, filetype, external_url, prepend_dir, stem,
+def command_line_interface(filename, filetype, external_url, stem,
                            output_file):
     """Launch the command line interface to interactively create the imgCIF.
 
@@ -167,8 +162,6 @@ def command_line_interface(filename, filetype, external_url, prepend_dir, stem,
         filename (str): the filename or directory name where the data is located
         filetype (str): the filetype of the files, either cbf or h5
         external_url (str): the external file url provided by the user
-        prepend_dir (str): the directory that should be prepended (directory name
-            as part of the archive path name)
         stem (str): Constant portion of frame file name. This can help determine the \
             scan/frame file naming convention
         output_file (str): output file to write to
@@ -183,7 +176,7 @@ def command_line_interface(filename, filetype, external_url, prepend_dir, stem,
 
     creator = imgcif_creator.ImgCIFCreator(filename, filetype, stem)
     creator.create_imgcif(
-        cif_block, external_url, prepend_dir, filename, filetype)
+        cif_block, external_url, filename, filetype)
 
     if output_file == '':
         output_file = os.getcwd() + os.sep + name + '.cif'

--- a/Tools/imgCIF_Creator/imgCIF_Creator/creator.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/creator.py
@@ -118,7 +118,7 @@ scan/frame file naming convention",
     # callback=validate_filename,
 )
 
-def main(filename, gui, external_url, stem, output_file):
+def main(filename, stem, output_file):
     """This is an interactive command line interface to collect the necessary
 information to create an imgCIF file out of HDF5, full CBF and some common subset
 of miniCBF
@@ -147,15 +147,10 @@ if you provide an input it will be checked against the required format.
     filename, filetype = validate_filename(filename)
     print(f'Identified content of {filename} as {filetype} file(s).')
 
-    if gui:
-        graphical_user_interface()
-    else:
-        command_line_interface(
-            filename, filetype, external_url, stem, output_file)
+    command_line_interface(filename, filetype, stem, output_file)
 
 
-def command_line_interface(filename, filetype, external_url, stem,
-                           output_file):
+def command_line_interface(filename, filetype, stem, output_file):
     """Launch the command line interface to interactively create the imgCIF.
 
     Args:
@@ -175,8 +170,7 @@ def command_line_interface(filename, filetype, external_url, stem,
     cif_file[name] = cif_block
 
     creator = imgcif_creator.ImgCIFCreator(filename, filetype, stem)
-    creator.create_imgcif(
-        cif_block, external_url, filename, filetype)
+    creator.create_imgcif(cif_block, filename, filetype)
 
     if output_file == '':
         output_file = os.getcwd() + os.sep + name + '.cif'
@@ -197,7 +191,3 @@ def command_line_interface(filename, filetype, external_url, stem,
         file.write(cif_file.WriteOut())
         print(f'Created imgCIF and saved to: {output_file}\n')
 
-
-def graphical_user_interface():
-
-    print('GUI not implemented yet!')

--- a/Tools/imgCIF_Creator/imgCIF_Creator/creator.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/creator.py
@@ -61,22 +61,22 @@ cbf and smv files please provide a directory. Exiting.')
 # )
 
 @click.command()
-@click.option(
-    "--gui",
-    "-g",
-    default=False,
-    type=bool,
-    is_flag=True,
-    help="Start the imgcif_creator with a graphical user interface.",
-)
+# @click.option(
+#     "--gui",
+#     "-g",
+#     default=False,
+#     type=bool,
+#     is_flag=True,
+#     help="Start the imgcif_creator with a graphical user interface.",
+# )
 
-@click.option(
-    "--external_url",
-    "-u",
-    type=str,
-    default='',
-    help='Final URL of files in output.'
-)
+# @click.option(
+#     "--external_url",
+#     "-u",
+#     type=str,
+#     default='',
+#     help='Final URL of files in output.'
+# )
 # this changed previously the uri, which is the file location before into the value
 # specified here
 # e.g. file://cbf_cyclohexane_crystal2/CBF_crystal_2/ciclohexano3_010001.cbf -->

--- a/Tools/imgCIF_Creator/imgCIF_Creator/information_extractors/hdf5_nxmx.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/information_extractors/hdf5_nxmx.py
@@ -377,7 +377,7 @@ class Extractor(extractor_interface.ExtractorInterface):
             # strangely this in encapsulated into two lists
             files = [tup[0] for tup in list(file_mapping.values())[0]]
             print(f"\nFound {n_files} files with {n_frames} frames in total: \n\
-{', '.join(files)}\n", end='')
+ {', '.join(files)}\n", end='')
             frame_numbers = parser.CommandLineParser().request_input('frame_numbers')
             frame_numbers = frame_numbers.replace(' ', '').split(',')
             frame_numbers = [int(number) for number in frame_numbers]

--- a/Tools/imgCIF_Creator/imgCIF_Creator/output_creator/block_generators.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/output_creator/block_generators.py
@@ -222,6 +222,7 @@ class ImgCIFEntryGenerators():
             entries[base + ".archive_path"] = []
 
         counter = 0
+        protocols = ["file:", "rsync:"]
         for scan, frames in scan_list:
             # print('sc fr scl', scan, frames, scan_list)
             for frame in range(1, frames + 1):
@@ -232,18 +233,20 @@ class ImgCIFEntryGenerators():
                 entries[base + ".id"].append(f"ext{counter}")
                 file_format = 'HDF5' if file_format == 'h5' else file_format
                 entries[base + ".format"].append(file_format.upper())
-                if external_url.startswith("file:"):
+                if any([external_url.startswith(prot) for prot in protocols]) or\
+                    file_format == 'HDF5':
+                    if file_format == 'HDF5':
+                        external_url = external_url.strip(external_url.split('/')[-1])
                     separator = '' if external_url.endswith(os.sep) else os.sep
                     local_url = external_url + separator + frame_name
                     entries[base + ".uri"].append(local_url)
                 else:
                     entries[base + ".uri"].append(external_url)
 
-                # TODO path and frame only for hdf5? repsectively containerized images?
+                # TODO path and frame only for hdf5? rspectively containerized images?
                 if file_format in ('h5', 'HDF5'):
                     entries[base + ".path"].append(all_frames[(scan, frame)]['path'])
                     entries[base + ".frame"].append(all_frames[(scan, frame)]['frame'])
-
                 # A too-clever-by-half way of optionally live constructing a URL
                 # TODO what is the archive path actually
                 if arch is not None:

--- a/Tools/imgCIF_Creator/imgCIF_Creator/output_creator/imgcif_creator.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/output_creator/imgcif_creator.py
@@ -49,7 +49,7 @@ class ImgCIFCreator:
         self.generators = block_generators.ImgCIFEntryGenerators()
 
 
-    def create_imgcif(self, cif_block, external_url, prepend_dir, filename, filetype):
+    def create_imgcif(self, cif_block, external_url, filename, filetype):
         """Add the required information to a cif_block and request the missing
         information from the user.
 
@@ -57,8 +57,6 @@ class ImgCIFCreator:
             cif_block (CifFile.CifFile_module.CifBlock): A cif block created with
                 the pycifrw package to which the information is added.
             external_url (str): An external url of the files e.g. a zeondo url
-            prepend_dir (str): If the directory name is included as part of the archive
-                path name this is the prepended directory name.
             filename (str): The filename or directory where the data is located.
             filetype (str): The filetype (smv, cbf or h5)
         """
@@ -99,8 +97,8 @@ class ImgCIFCreator:
         detector_info = self.extractor.get_detector_info()
         detector_info = self.check_detector_completeness(detector_info, axes_info)
 
-        archive, external_url = self.check_external_url(external_url, filename)
-
+        archive, external_url, archive_path = self.check_external_url(
+            external_url, filename)
 
         # now generate the cif block
         # _diffrn_source block
@@ -127,7 +125,7 @@ class ImgCIFCreator:
         # self.generate _array_data_external_data
         self.generators.generate_external_ids(
             cif_block, external_url, self.extractor.all_frames,
-            scan_list, archive, prepend_dir, filetype)
+            scan_list, archive, archive_path, filetype)
 
 
     def check_misc_completeness(self, misc_info):
@@ -455,6 +453,7 @@ class ImgCIFCreator:
         """
 
         archive = None
+        archive_path = None
 
         if external_url == '':
             external_url = self.cmd_parser.request_input('external_url')
@@ -470,9 +469,10 @@ class ImgCIFCreator:
         for archive_type, regex in archives.items():
             searched = re.search(regex, external_url)
             if bool(searched) and searched.group(0) != '':
-                return archive_type, external_url
+                archive_path = self.cmd_parser.request_input('archive_path')
+                return archive_type, external_url, archive_path
 
-        return archive, external_url
+        return archive, external_url, archive_path
 
 
     def _change_axes(self, axes_files, parser_label):

--- a/Tools/imgCIF_Creator/imgCIF_Creator/output_creator/imgcif_creator.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/output_creator/imgcif_creator.py
@@ -465,7 +465,8 @@ class ImgCIFCreator:
                 enter_url = False
             if enter_url:
                 del self.cmd_parser.parsed['external_url']
-                
+                del self.cmd_parser.parsed['url_not_reachable']
+
         if external_url == 'force local':
             filename = filename[1:] if filename.startswith(os.sep) else filename
             external_url = f"file:{os.sep}{os.sep}" + filename
@@ -492,7 +493,7 @@ class ImgCIFCreator:
         Returns:
             bool: whether the url is reachable or not
         """
-        
+
         try:
             get = requests.get(url)
             if get.status_code == 200:

--- a/Tools/imgCIF_Creator/imgCIF_Creator/output_creator/imgcif_creator.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/output_creator/imgcif_creator.py
@@ -50,14 +50,13 @@ class ImgCIFCreator:
         self.generators = block_generators.ImgCIFEntryGenerators()
 
 
-    def create_imgcif(self, cif_block, external_url, filename, filetype):
+    def create_imgcif(self, cif_block, filename, filetype):
         """Add the required information to a cif_block and request the missing
         information from the user.
 
         Args:
             cif_block (CifFile.CifFile_module.CifBlock): A cif block created with
                 the pycifrw package to which the information is added.
-            external_url (str): An external url of the files e.g. a zeondo url
             filename (str): The filename or directory where the data is located.
             filetype (str): The filetype (smv, cbf or h5)
         """
@@ -98,8 +97,7 @@ class ImgCIFCreator:
         detector_info = self.extractor.get_detector_info()
         detector_info = self.check_detector_completeness(detector_info, axes_info)
 
-        archive, external_url, archive_path = self.check_external_url(
-            external_url, filename)
+        archive, external_url, archive_path = self.check_external_url(filename)
 
         # now generate the cif block
         # _diffrn_source block
@@ -440,13 +438,11 @@ class ImgCIFCreator:
         return param_dict
 
 
-    def check_external_url(self, external_url, filename):
+    def check_external_url(self, filename):
         """Get the archive type of the provided external url or return the default
         filename/path as external url if no external url was provided.
 
         Args:
-            external_url (str): the external url wich possibly points to an archive
-                format
             filename (str): The filename or directory where the data is located.
 
         Returns:
@@ -457,19 +453,18 @@ class ImgCIFCreator:
         archive_path = None
         enter_url = True
 
-        if external_url == '':
-            while enter_url:
-                external_url = self.cmd_parser.request_input('external_url')
-                print(' ==> Checking url...')
-                url_is_reachable = self._check_url_is_reachable(external_url)
-                if not url_is_reachable:
-                    response = self.cmd_parser.request_input('url_not_reachable')
-                    enter_url = True if 'y' in response else False
-                else:
-                    print(f' ==> {external_url} is reachable!')
-                    enter_url = False
-                if enter_url:
-                    del self.cmd_parser.parsed['external_url']
+        while enter_url:
+            external_url = self.cmd_parser.request_input('external_url')
+            print(' ==> Checking url...')
+            url_is_reachable = self._check_url_is_reachable(external_url)
+            if not url_is_reachable:
+                response = self.cmd_parser.request_input('url_not_reachable')
+                enter_url = True if 'y' in response else False
+            else:
+                print(f' ==> {external_url} is reachable!')
+                enter_url = False
+            if enter_url:
+                del self.cmd_parser.parsed['external_url']
                 
         if external_url == 'force local':
             filename = filename[1:] if filename.startswith(os.sep) else filename

--- a/Tools/imgCIF_Creator/imgCIF_Creator/resources/user_input.yaml
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/resources/user_input.yaml
@@ -382,3 +382,14 @@ archive_path:
       The exteral url points to an archive, please specify the path within the archive
       where the files can be found.
 
+
+url_not_reachable:
+    label: The url is not reachable
+    required: true
+    description: >
+       The url you have entered is (currently) not reachable - do you want to enter it
+       again?
+    options:
+      - 'Yes'
+      - 'No'
+    abbreviate: true

--- a/Tools/imgCIF_Creator/imgCIF_Creator/resources/user_input.yaml
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/resources/user_input.yaml
@@ -388,7 +388,7 @@ url_not_reachable:
     required: true
     description: >
        The url you have entered is (currently) not reachable - do you want to enter it
-       again?
+       again? Please provide the full url.
     options:
       - 'Yes'
       - 'No'

--- a/Tools/imgCIF_Creator/imgCIF_Creator/resources/user_input.yaml
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/resources/user_input.yaml
@@ -352,7 +352,8 @@ external_url:
     label: External url
     required: true
     description: >
-      Please enter the URL where the files can be found (e.g. a zenodo URL). If
+      Please enter the URL where the files can be found (e.g. a zenodo URL). Please
+      provide a link to the the archive file, the folder or hdf5 master file. If
       you can not provide an external URL you can use the local file location by
       entering 'force local' (discouraged).
 
@@ -373,3 +374,11 @@ keep_axes:
       - 'Yes'
       - 'No'
     abbreviate: true
+
+archive_path:
+    label: Archive path
+    required: true
+    description: >
+      The exteral url points to an archive, please specify the path within the archive
+      where the files can be found.
+


### PR DESCRIPTION
This PR addresses #47 

- The construction of the urls for the hdf5 files has been corrected. Now the urls for the individual files in the external links of the hdf5 master are used for the construction of urls.
- The program now also asks the user for the archive path if an url that points to an archive is detected.
- After the user enters an url the program now checks also if this url is reachable and if not it asks the user if he want to enter the url again.