### PR TITLE
add rounding for scan range due to unprecise calculation

### DIFF
--- a/Tools/imgCIF_Creator/imgCIF_Creator/information_extractors/cbf_smv.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/information_extractors/cbf_smv.py
@@ -527,7 +527,8 @@ as goniometer or detector axes.")
                             "incr" : scan_incr,
                             "time" : exposure,
                             "start" : start,
-                            "range" : scan_incr * len(frames),
+                            # because of 0.1*137 = 13.700000000000001 we round
+                            "range" : round(scan_incr * len(frames), 10),
                             "wavelength" : wavelength,
                             "x_pixel_size" : x_pixel_size,
                             "y_pixel_size" : y_pixel_size,

--- a/Tools/imgCIF_Creator/imgCIF_Creator/information_extractors/hdf5_nxmx.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/information_extractors/hdf5_nxmx.py
@@ -251,7 +251,8 @@ class Extractor(extractor_interface.ExtractorInterface):
                             if goniometer_rot_direction in ['anticlockwise', 'a']:
                                 scan_incr = scan_incr * -1
                                 scan_stop *= -1
-                            scan_range = n_frames * scan_incr
+                            # because of 0.1*137 = 13.700000000000001 we round
+                            scan_range = round(scan_incr * n_frames, 10)
                     except TypeError:
                         # for fast and slow this is a scalar and no list
                         pass


### PR DESCRIPTION
By multiplying the number of frames with the increment the multiplication is not exact: `0.1*132 = 13.200000000000001`, resulting in:
```
         SCAN1     omega     .         .         .         -162.9    0.1 
          13.200000000000001  
```
which doesn't look nice. This could be rounded as done here. If you don't think it's necessary I can discard it.  