### PR TITLE
External url and archive

### DIFF
--- a/Tools/imgCIF_Creator/imgCIF_Creator/output_creator/imgcif_creator.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/output_creator/imgcif_creator.py
@@ -438,7 +438,7 @@ class ImgCIFCreator:
             external_url = self.cmd_parser.request_input('external_url')
             if external_url == 'force local':
                 filename = filename[1:] if filename.startswith(os.sep) else filename
-                external_url = f"file:{os.sep}{os.sep}" + os.getcwd() + filename
+                external_url = f"file:{os.sep}" + os.getcwd() + filename
                 enter_url = False
             else:
                 print(' ==> Checking url...')

--- a/Tools/imgCIF_Creator/imgCIF_Creator/output_creator/imgcif_creator.py
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/output_creator/imgcif_creator.py
@@ -436,21 +436,23 @@ class ImgCIFCreator:
 
         while enter_url:
             external_url = self.cmd_parser.request_input('external_url')
-            print(' ==> Checking url...')
-            url_is_reachable = self._check_url_is_reachable(external_url)
-            if not url_is_reachable:
-                response = self.cmd_parser.request_input('url_not_reachable')
-                enter_url = True if 'y' in response else False
-            else:
-                print(f' ==> {external_url} is reachable!')
+            if external_url == 'force local':
+                filename = filename[1:] if filename.startswith(os.sep) else filename
+                external_url = f"file:{os.sep}{os.sep}" + os.getcwd() + filename
                 enter_url = False
-            if enter_url:
-                del self.cmd_parser.parsed['external_url']
-                del self.cmd_parser.parsed['url_not_reachable']
+            else:
+                print(' ==> Checking url...')
+                url_is_reachable = self._check_url_is_reachable(external_url)
+                if not url_is_reachable:
+                    response = self.cmd_parser.request_input('url_not_reachable')
+                    enter_url = True if 'y' in response else False
+                else:
+                    print(f' ==> {external_url} is reachable!')
+                    enter_url = False
+                if enter_url:
+                    del self.cmd_parser.parsed['external_url']
+                    del self.cmd_parser.parsed['url_not_reachable']
 
-        if external_url == 'force local':
-            filename = filename[1:] if filename.startswith(os.sep) else filename
-            external_url = f"file:{os.sep}{os.sep}" + filename
 
         archives = {"TGZ" : r"(\.tgz)|(\.tar.gz)\Z",
                     "TBZ" : r"(\.tbz)|(\.tar\.bz2)\Z",

--- a/Tools/imgCIF_Creator/imgCIF_Creator/resources/user_input.yaml
+++ b/Tools/imgCIF_Creator/imgCIF_Creator/resources/user_input.yaml
@@ -298,14 +298,14 @@ keep_axes:
 
 archive_path:
     label: Archive path
-    required: true
+    required: false
     description: >
       The exteral url points to an archive, please specify the path within the archive
       where the files can be found.
 
 
 url_not_reachable:
-    label: The url is not reachable
+    label: Enter url again?
     required: true
     description: >
        The url you have entered is (currently) not reachable - do you want to enter it


### PR DESCRIPTION
- The 'force local' option for the url did still check the availability of the url and used only the filename as path. This PR changes the behaviour such that the full path of the file is used and the url is not checked for the local option.
something along the lines:
` ext1      CBF       file://home/instrument-geometry-info/Toolscbf_cyclohexane_crystal2/CBF_crystal_2/ciclohexano3_010001.cbf`

- I made the archive path optional, now you can enter empty archive paths as well. I also changed the wording of the enter url again question.

actually I did't test if there will be a problem if you would run it on windows and use the local option
Does that fix your problems?