### PR TITLE
Use dxtbx to read .expt JSON files

### DIFF
--- a/Tools/dials2imgcif.py
+++ b/Tools/dials2imgcif.py
@@ -696,6 +696,11 @@ def parse_commandline(argv):
              "The result is incomplete, so remove this option again to generate "
              "the full ImgCIF file."
     )
+    ap.add_argument(
+        '--no-check-format', action='store_true',
+        help="Skip dxtbx checking the data file format. Needed if you don't have the "
+             "data files which a DIALS .expt file points to."
+    )
     args = ap.parse_args(argv)
 
     return args
@@ -711,7 +716,9 @@ def main():
 
     with out_fn.open('w') as outf:
         outf.write(CIF_HEADER.format(name=out_fn.stem))
-        expts = ExperimentListFactory.from_json_file(args.input_fn)
+        expts = ExperimentListFactory.from_json_file(
+            args.input_fn, check_format=(not args.no_check_format)
+        )
 
         write_beam_info(expts, outf)
 


### PR DESCRIPTION
This uses DIALS' [dxtbx](https://github.com/cctbx/dxtbx) library to read the experiment JSON file, instead of taking the fields from the JSON directly. For now this is a more dependency-heavy way to achieve exactly the same results, but the next step is to work directly with the input file formats that dxtbx recognises, skipping the `dials.import` step.

dxtbx appears to be distributed only as a conda package, not as a pip-installable package, so the easiest way to use this is to create a conda environment:

```shell
conda create --name dials2imgcif --channel conda-forge python dxtbx h5py scipy
conda activate dials2imgcif
```

(See https://conda-forge.org/download/ if you need conda)

@jamesrhester I thought this might be a good point to pause for some code review, if you have time. I'm also happy to carry on, though.